### PR TITLE
refactor: remove unused parameter from method signature

### DIFF
--- a/TWCommonLib/TWCommonLib/NSObject+TWObjectLifetime.h
+++ b/TWCommonLib/TWCommonLib/NSObject+TWObjectLifetime.h
@@ -12,6 +12,6 @@
 
 - (void)tw_bindLifetimeTo:(nonnull NSObject *)owner usingKey:(nonnull NSString *)key;
 - (nullable id)tw_getAttachedObjectWithKey:(nonnull NSString *)key;
-- (void)tw_releaseAttachedObjectFromOwner:(nonnull NSObject *)owner withKey:(nonnull NSString *)key;
+- (void)tw_releaseAttachedObjectWithKey:(nonnull NSString *)key;
 
 @end

--- a/TWCommonLib/TWCommonLib/NSObject+TWObjectLifetime.m
+++ b/TWCommonLib/TWCommonLib/NSObject+TWObjectLifetime.m
@@ -52,9 +52,8 @@
   return results[0];
 }
 
-- (void)tw_releaseAttachedObjectFromOwner:(nonnull NSObject *)owner withKey:(nonnull NSString *)key
+- (void)tw_releaseAttachedObjectWithKey:(nonnull NSString *)key
 {
-  AssertTrueOrReturn(owner);
   AssertTrueOrReturn(key.length);
   objc_setAssociatedObject(self, (__bridge const void *)(key), nil, OBJC_ASSOCIATION_RETAIN);
 }

--- a/TWCommonLib/TWCommonLib/UIViewController+TWNotificationObserving.m
+++ b/TWCommonLib/TWCommonLib/UIViewController+TWNotificationObserving.m
@@ -50,7 +50,7 @@ static NSString *const kBindingKey = @"NotificationsNameToSelectorMapping";
   id mapping = [self tw_getAttachedObjectWithKey:kBindingKey];
   AssertTrueOrReturn(mapping);
   AssertTrueOrReturn([mapping isKindOfClass:[NSDictionary class]]);
-  [self tw_releaseAttachedObjectFromOwner:self withKey:kBindingKey];
+  [self tw_releaseAttachedObjectWithKey:kBindingKey];
   [self tw_removeNotificationsWithNameToSelectorMapping:mapping];
 }
 


### PR DESCRIPTION
Seems that `owner` parameter isn't used in the implementation, thus it's presence in a signature is misleading (true story!)
